### PR TITLE
Sort Flipnotes by dates

### DIFF
--- a/scripts/generateManifest.js
+++ b/scripts/generateManifest.js
@@ -20,7 +20,8 @@ Promise.all(meta['items'].map(item => {
         filestem: filestem,
         author: note.meta.current.username,
         ext: note.type.toLowerCase(),
-        thumb: imageUrl, 
+        thumb: imageUrl,
+        timestamp: note.meta.timestamp
       }
     });
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,10 @@ fetch('./static/manifest.json')
       ...item,
       src: `./static/${item.ext}/${item.filestem}.${item.ext}`
     }));
+
+    items.map(x => x.timestamp = new Date(x.timestamp));
+    items.sort((a, b) => b.timestamp - a.timestamp);
+
     GridStore.update(store => {
       store.samples = items;
       store.items = items;

--- a/src/components/FlipnoteThumb.jsx
+++ b/src/components/FlipnoteThumb.jsx
@@ -1,7 +1,7 @@
 import '@/styles/components/FlipnoteThumb.scss';
 import Icon from '@/components/Icon';
 
-const FlipnoteThumb = ({ placeholder, ext, src, thumb, author, onSelect, lock }) => (
+const FlipnoteThumb = ({ placeholder, ext, src, thumb, author, onSelect, lock, timestamp }) => (
   <div className="FlipnoteThumb" onClick={(e) => { onSelect(src) }}>
     <div className="FlipnoteThumb__image" style={{ "backgroundImage": `url(${ thumb })` }}>
       { ext && (
@@ -15,6 +15,9 @@ const FlipnoteThumb = ({ placeholder, ext, src, thumb, author, onSelect, lock })
     </div>
     <div className="FlipnoteThumb__info">
       <span className="FlipnoteThumb__author">{ author }</span>
+      <span className="FlipnoteThumb__date">
+          { timestamp === undefined ? "" : timestamp.toLocaleDateString() }
+      </span>
     </div>
   </div>
 )

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -42,6 +42,7 @@ export default (props) => {
       startLoading();
       GridStore.update(store => { store.items = []; });
       loadFiles(files).then(items => {
+        items.sort((a, b) => b.timestamp - a.timestamp);
         GridStore.update(store => { store.items = items; store.mode = 'UPLOADS'; store.page = 0; });
         stopLoading();
       });

--- a/src/styles/components/FlipnoteThumb.scss
+++ b/src/styles/components/FlipnoteThumb.scss
@@ -42,10 +42,16 @@
   line-height: 1rem;
   overflow: hidden;
   padding-top: 6px;
+  display: flex;
+  justify-content: space-between;
 }
 
 .FlipnoteThumb__author {
   color: $primary-color;
+}
+
+.FlipnoteThumb__date {
+  font-size: 0.8em;
 }
 
 .FlipnoteThumb__type {

--- a/src/utils/loadFiles.js
+++ b/src/utils/loadFiles.js
@@ -43,7 +43,8 @@ export function getFlipnoteMeta(flipnote) {
       ext: flipnote.type.toLowerCase(),
       filename: meta.current.filename,
       thumb: thumb.getUrl(),
-      note: flipnote
+      note: flipnote,
+      timestamp: meta.timestamp
     };
     resolve(item);
     }


### PR DESCRIPTION
Slight changes that sort the uploaded Flipnotes by dates so that they are displayed the same way as on the console (kinda), which feels a bit more convenient. This also displays the date below the thumbnail.

The sample Flipnotes are also sorted by dates for consistency. Not sure if this is relevant though.